### PR TITLE
Do not show current date if there is no date defined

### DIFF
--- a/templates/portfolio-meta.php
+++ b/templates/portfolio-meta.php
@@ -10,7 +10,9 @@ $id               = get_the_ID();
 $client_name      = get_post_meta( $id, '_client_name', true );
 $project_url      = get_post_meta( $id, '_project_url', true );
 $project_date     = get_post_meta( $id, '_project_date', true );
-$project_date     = date_i18n( get_option( 'date_format' ), strtotime( $project_date ) );
+if ( $project_date ) {
+	$project_date = date_i18n( get_option( 'date_format' ), strtotime( $project_date ) );
+}
 $categories       = get_the_terms( $id, 'portfolio_cat' );
 $categories_names = is_array( $categories ) ? wp_list_pluck( $categories, 'name' ) : array();
 $skills           = get_the_terms( $id, 'portfolio_skill' );


### PR DESCRIPTION
Hi,

I'm refering to this WordPress forum post : https://wordpress.org/support/topic/filter-hook-for-date-removal-not-working/

In the FAQ (https://wordpress.org/plugins/filterable-portfolio/#i%20want%20to%20remove%20project%20date.%20is%20it%20possible%3F) you give a way to get rid of project date using the `filterable_portfolio_meta_box_fields` filter. Actualy using this filter removes the field in the back-end, as you say it does, but the meta info is still rendered on the single portfolio page displaying the current date !

This is because function `date_i18n` your are using returns the current date if no timestamp is provided... And, as you test for an empty `$project_date` variable before displaying this meta, I'm assuming you did not expect this beaviour :)

So here is my proposal : test if `$project_date` actualy exists before you apply `date_i18n` on it. If it does not exists, then skip this unuseful part and do not display the meta :)

Hope you may correct this unexpected beaviour this way or any other way you may think of because I'm using this plugin and do not want to display any date...

By the way, thank you very much for giving us this work for free. It is greatly appreciated :)

Séb.