### PR TITLE
Make tinyslider object accessible

### DIFF
--- a/assets/src/frontend/slider.js
+++ b/assets/src/frontend/slider.js
@@ -56,7 +56,7 @@
         slideBy = slider.getAttribute('data-slide-by');
         slideBy = (slideBy === 'page') ? 'page' : parseInt(slideBy);
 
-        tns({
+        slider.tinySlider=tns({
             container: slider,
             slideBy: slideBy,
             loop: loop,


### PR DESCRIPTION
Hi,

I could not find any other way to access the tns object properties but attaching it to the slider itself because I needed to use a callback on slider swipe event. With this small modification I can do :

`document.querySelector('.single-portfolio #tns1').tinySlider.events.on('touchStart',function(){...});`

Is there any other way you could suggest ?

Thanks for your reply.

Séb.