### PR TITLE
Actions before and after single portfolio content/meta

### DIFF
--- a/templates/single-portfolio.php
+++ b/templates/single-portfolio.php
@@ -14,13 +14,17 @@ $options = Filterable_Portfolio_Helper::get_options();
     <div class="grids">
         <div class="project-content grid s8">
             <h4><?php echo esc_attr( $options['project_description_text'] ); ?></h4>
-			<?php echo do_shortcode( get_the_content() ); ?>
+            <?php do_action( 'filterable_portfolio_before_single_portfolio_content' ); ?>
+            <?php echo do_shortcode( get_the_content() ); ?>
+            <?php do_action( 'filterable_portfolio_after_single_portfolio_content' ); ?>
         </div>
         <div class="project-meta grid s4">
-			<?php
-			$template = FILTERABLE_PORTFOLIO_TEMPLATES . '/portfolio-meta.php';
-			load_template( $template, false );
-			?>
+            <?php do_action( 'filterable_portfolio_before_single_portfolio_meta' ); ?>
+            <?php
+            $template = FILTERABLE_PORTFOLIO_TEMPLATES . '/portfolio-meta.php';
+            load_template( $template, false );
+            ?>
+            <?php do_action( 'filterable_portfolio_after_single_portfolio_meta' ); ?>
         </div>
     </div>
 	<?php


### PR DESCRIPTION
Hi,

Sorry for all those PR but as I'm actualy using your plugin for my own portfolio, I come to you each time I cannot do what I want to do without modifying your source code... I hope I do not disturb you too much :)

This PR is because of the way you handle "the content" in the `Filterable_Portfolio_Single_Post` class. I need to add some content just after the single portfolio description but it is actualy not possible because the "related posts" are part of "the content" and because I don't want to rely on some impossible regex to inject my own content...

So I propose to add these 4 hooks before and after portfolio content and meta. This way, anyone could inject anything easily :)

What do you think about this way of doing things ?

Thanks.

Séb.